### PR TITLE
Display stacktrace as part of report

### DIFF
--- a/composer/build.gradle
+++ b/composer/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     compile libraries.apacheCommonsLang
     compile libraries.gson
     compile libraries.dexParser
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }
 
 dependencies {
@@ -105,5 +106,27 @@ publishing {
                 root.children().last() + pomConfig
             }
         }
+    }
+}
+buildscript {
+    ext.kotlin_version = '1.2.0'
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+repositories {
+    mavenCentral()
+}
+compileKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+compileTestKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
     }
 }


### PR DESCRIPTION
Structure of failed test is now.:

- Header (failed/passed, name of test)
- Screenshots
- Stacktrace
- Logcat

Illustration

![image](https://user-images.githubusercontent.com/990654/236186662-69de8b22-ec14-4cea-85cb-c580346c3e88.png)
