### PR TITLE
Fix issue where ADB logcat process was not killed when exception occured in orchestrator

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,7 +3,7 @@ ext.versions = [
 
         rxJava           : '1.3.0',
         jCommander       : '1.71',
-        commander        : '0.2.2',
+        commander        : '0.2.3',
         apacheCommonsIo  : '2.5',
         apacheCommonsLang: '3.5',
         gson             : '2.8.0',


### PR DESCRIPTION
Now properly tested. Reproduced by forcefully killing the test orchestrator mid-execution.

Log output proving ADB was killed:
```
10:03:55: Executing ':composer:MainKt.main()'...

Parallel execution is an incubating feature.

> Task :composer:compileKotlin
w: Runtime JAR files in the classpath should have the same version. These files were found in the classpath:
    C:/Users/nilzo/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.2.0/19f2e2850a84628d9219c251eb7b9ed6da37fd7b/kotlin-stdlib-jdk8-1.2.0.jar (version 1.2)
    C:/Users/nilzo/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.2.0/695eb1099f1b85b19e076b051faa2054a8df5c43/kotlin-stdlib-jdk7-1.2.0.jar (version 1.2)
    C:/Users/nilzo/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.3.72/8032138f12c0180bc4e51fe139d4c52b46db6109/kotlin-stdlib-1.3.72.jar (version 1.3)
    C:/Users/nilzo/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.3.72/6ca8bee3d88957eaaaef077c41c908c9940492d8/kotlin-stdlib-common-1.3.72.jar (version 1.3)
w: Some runtime JAR files in the classpath have an incompatible version. Consider removing them from the classpath

> Task :composer:compileJava NO-SOURCE
> Task :composer:processResources UP-TO-DATE
> Task :composer:classes UP-TO-DATE

> Task :composer:MainKt.main()
[Tue Oct 10 10:03:56 CEST 2023]: 2 connected adb device(s): [AdbDevice(id=R5CT7201FWX, model=SM-G990B2, online=true), AdbDevice(id=192.168.0.106:5555, model=SM-T575, online=true)]
[Tue Oct 10 10:03:56 CEST 2023]: [192.168.0.106:5555] Installing apk... pathToApk = C:\temp\a\rutersalg-qaDebug-RS-5654-print-receipt-08-09-2023-139c146e2d-qa-debug.apk
[Tue Oct 10 10:03:56 CEST 2023]: [R5CT7201FWX] Installing apk... pathToApk = C:\temp\a\rutersalg-qaDebug-RS-5654-print-receipt-08-09-2023-139c146e2d-qa-debug.apk
[Tue Oct 10 10:03:59 CEST 2023]: [R5CT7201FWX] Successfully installed apk in 2 seconds, pathToApk = C:\temp\a\rutersalg-qaDebug-RS-5654-print-receipt-08-09-2023-139c146e2d-qa-debug.apk
[Tue Oct 10 10:03:59 CEST 2023]: [R5CT7201FWX] Installing apk... pathToApk = C:\temp\a\app-rutersalg-qa-debug-androidTest.apk
[Tue Oct 10 10:04:01 CEST 2023]: [R5CT7201FWX] Successfully installed apk in 1 second, pathToApk = C:\temp\a\app-rutersalg-qa-debug-androidTest.apk
[Tue Oct 10 10:04:01 CEST 2023]: [R5CT7201FWX] Will pull screenshots from device folder /sdcard/Pictures/spoon-screenshots
[Tue Oct 10 10:04:01 CEST 2023]: [R5CT7201FWX] Starting tests...
[Tue Oct 10 10:04:01 CEST 2023]: [R5CT7201FWX] Logcat cleared
[Tue Oct 10 10:04:01 CEST 2023]: [R5CT7201FWX] Logcat parsing process started with PID 16576
[Tue Oct 10 10:04:04 CEST 2023]: [R5CT7201FWX] Test run finished, 0 passed, 0 failed, took 3 seconds.
[Tue Oct 10 10:04:04 CEST 2023]: [R5CT7201FWX] Stopping ADB logcat listener - PID 16576
[Tue Oct 10 10:04:10 CEST 2023]: [192.168.0.106:5555] Successfully installed apk in 13 seconds, pathToApk = C:\temp\a\rutersalg-qaDebug-RS-5654-print-receipt-08-09-2023-139c146e2d-qa-debug.apk
[Tue Oct 10 10:04:10 CEST 2023]: [192.168.0.106:5555] Installing apk... pathToApk = C:\temp\a\app-rutersalg-qa-debug-androidTest.apk
[Tue Oct 10 10:04:13 CEST 2023]: [192.168.0.106:5555] Successfully installed apk in 2 seconds, pathToApk = C:\temp\a\app-rutersalg-qa-debug-androidTest.apk
[Tue Oct 10 10:04:13 CEST 2023]: [192.168.0.106:5555] Will pull screenshots from device folder /sdcard/Pictures/spoon-screenshots
[Tue Oct 10 10:04:13 CEST 2023]: [192.168.0.106:5555] Starting tests...
[Tue Oct 10 10:04:13 CEST 2023]: [192.168.0.106:5555] Logcat cleared
[Tue Oct 10 10:04:13 CEST 2023]: [192.168.0.106:5555] Logcat parsing process started with PID 4364
[Tue Oct 10 10:04:30 CEST 2023]: [192.168.0.106:5555] Error during tests run: java.lang.Exception: Application process crashed. Check Logcat output for more details.
[Tue Oct 10 10:04:30 CEST 2023]: [192.168.0.106:5555] Killing ADB process with PID 4364
Exception in thread "main" java.lang.RuntimeException: java.lang.Exception: Application process crashed. Check Logcat output for more details.
	at rx.exceptions.Exceptions.propagate(Exceptions.java:57)
	at rx.observables.BlockingObservable.blockForSingle(BlockingObservable.java:463)
	at rx.observables.BlockingObservable.first(BlockingObservable.java:166)
	at com.gojuno.composer.MainKt.runAllTests(Main.kt:208)
	at com.gojuno.composer.MainKt.main(Main.kt:65)
Caused by: java.lang.Exception: Application process crashed. Check Logcat output for more details.
	at com.gojuno.composer.InstrumentationKt.throwIfError(Instrumentation.kt:68)
	at com.gojuno.composer.InstrumentationKt.access$throwIfError(Instrumentation.kt:1)
	at com.gojuno.composer.InstrumentationKt$readInstrumentationOutput$2.call(Instrumentation.kt:114)
	at com.gojuno.composer.InstrumentationKt$readInstrumentationOutput$2.call(Instrumentation.kt)
	at rx.internal.operators.OnSubscribeMap$MapSubscriber.onNext(OnSubscribeMap.java:69)
	at rx.internal.operators.OnSubscribeMap$MapSubscriber.onNext(OnSubscribeMap.java:77)
	at rx.internal.operators.OnSubscribeCreate$BufferEmitter.drain(OnSubscribeCreate.java:366)
	at rx.internal.operators.OnSubscribeCreate$BufferEmitter.onNext(OnSubscribeCreate.java:299)
	at com.gojuno.composer.FilesKt$tail$1$1.handle(Files.kt:15)
	at org.apache.commons.io.input.Tailer.readLines(Tailer.java:528)
	at org.apache.commons.io.input.Tailer.run(Tailer.java:459)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: rx.exceptions.OnErrorThrowable$OnNextValue: OnError while emitting onNext value: INSTRUMENTATION_RESULT: shortMsg=Process crashed.
	at rx.exceptions.OnErrorThrowable.addValueAsLastCause(OnErrorThrowable.java:118)
	at rx.internal.operators.OnSubscribeMap$MapSubscriber.onNext(OnSubscribeMap.java:73)
	... 7 more

> Task :composer:MainKt.main() FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':composer:MainKt.main()'.
> Process 'command 'C:/Program Files/ojdkbuild/java-11-openjdk-11.0.5-1/bin/java.exe'' finished with non-zero exit value 1

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/4.9/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 35s
3 actionable tasks: 2 executed, 1 up-to-date
10:04:30: Execution finished ':composer:MainKt.main()'.

```